### PR TITLE
update run marker to be on at start and off at stop-trigger-sources 

### DIFF
--- a/plugins/CRTBernReaderModule.cpp
+++ b/plugins/CRTBernReaderModule.cpp
@@ -197,11 +197,18 @@ CRTBernReaderModule::do_start(const nlohmann::json& /*startobj*/)
     source->acquire_callback();
   }
 
-  enable_flow();  
-
   m_packet_count = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();
+
+  // Configure HW interface?
+  if (!m_run_marker.load()) {
+    set_running(true);
+  } else {
+    TLOG_DEBUG(5) << "Already running!";
+  }  
+
+  enable_flow();  
 
   //if (!m_callback_mode) {
     m_producer_thread.set_work(&CRTBernReaderModule::run_produce, this);
@@ -212,6 +219,18 @@ void
 CRTBernReaderModule::do_stop(const nlohmann::json& /*stopobj*/)
 {
   disable_flow();
+
+  if (m_run_marker.load()) {
+    TLOG() << "Raising stop through variables!";
+    set_running(false);
+//  if (!m_callback_mode) {
+    while (!m_producer_thread.get_readiness()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+//  }      
+  } else {
+    TLOG_DEBUG(5) << "Already stopped!";
+  }  
 }
 
 void

--- a/plugins/CRTGrenobleReaderModule.cpp
+++ b/plugins/CRTGrenobleReaderModule.cpp
@@ -201,6 +201,13 @@ CRTGrenobleReaderModule::do_start(const nlohmann::json& /*startobj*/)
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
+  // Configure HW interface?
+  if (!m_run_marker.load()) {
+    set_running(true);
+  } else {
+    TLOG_DEBUG(5) << "Already running!";
+  }  
+
   enable_flow();  
 
   //if (!m_callback_mode) {
@@ -212,6 +219,18 @@ void
 CRTGrenobleReaderModule::do_stop(const nlohmann::json& /*stopobj*/)
 {
   disable_flow();
+
+  if (m_run_marker.load()) {
+    TLOG() << "Raising stop through variables!";
+    set_running(false);
+//  if (!m_callback_mode) {
+    while (!m_producer_thread.get_readiness()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+//  }      
+  } else {
+    TLOG_DEBUG(5) << "Already stopped!";
+  }  
 }
 
 void


### PR DESCRIPTION
(… trying to avoid an infinite while loop)

This is in response to the issue raised here: https://github.com/DUNE-DAQ/daqsystemtest/issues/218

@bieryAtFnal reports that this resolved the problem when he ran it (though @denizergonul and I were not able to reproduce the problem in our own tests).