### PR TITLE
Modified crt_reader_test.py so that it uses a single base system configuration...

### DIFF
--- a/integtest/crt_reader_test.py
+++ b/integtest/crt_reader_test.py
@@ -32,10 +32,100 @@ common_config_obj.config_db = (
 )
 
 onebyone_local_crt_bern_conf = copy.deepcopy(common_config_obj)
-onebyone_local_crt_bern_conf.session = "local-crt-bern-1x1-config"
+onebyone_local_crt_bern_conf.session = "local-socket-1x1-config"
+
+onebyone_local_crt_bern_conf.config_substitutions.append(
+    data_classes.relationship_substitution(
+        obj_class="CRTReaderApplication",
+        obj_id="crt-data-source-01",
+        rel_name="data_reader",
+        replacement_object_class="CRTBernReaderConf",
+        replacement_object_id="def-crt-bern-receiver-conf"
+    )
+)
+onebyone_local_crt_bern_conf.config_substitutions.append(
+    data_classes.list_element_substitution(
+        obj_class="ActionPlan",
+        obj_id="crt-readout-start",
+        rel_name="steps",
+        list_index=1,
+        replacement_object_class="DaqModulesGroupByType",
+        replacement_object_id="crt-bern-reader-data-source-step"
+    )
+)
+onebyone_local_crt_bern_conf.config_substitutions.append(
+    data_classes.list_element_substitution(
+        obj_class="ActionPlan",
+        obj_id="crt-readout-stop",
+        rel_name="steps",
+        list_index=0,
+        replacement_object_class="DaqModulesGroupByType",
+        replacement_object_id="crt-bern-reader-data-source-step"
+    )
+)
 
 onebyone_local_crt_grenoble_conf = copy.deepcopy(common_config_obj)
-onebyone_local_crt_grenoble_conf.session = "local-crt-grenoble-1x1-config"
+onebyone_local_crt_grenoble_conf.session = "local-socket-1x1-config"
+
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.relationship_substitution(
+        obj_class="CRTReaderApplication",
+        obj_id="crt-data-source-01",
+        rel_name="data_reader",
+        replacement_object_class="CRTGrenobleReaderConf",
+        replacement_object_id="def-crt-grenoble-receiver-conf"
+    )
+)
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.list_element_substitution(
+        obj_class="ActionPlan",
+        obj_id="crt-readout-start",
+        rel_name="steps",
+        list_index=1,
+        replacement_object_class="DaqModulesGroupByType",
+        replacement_object_id="crt-grenoble-reader-data-source-step"
+    )
+)
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.list_element_substitution(
+        obj_class="ActionPlan",
+        obj_id="crt-readout-stop",
+        rel_name="steps",
+        list_index=0,
+        replacement_object_class="DaqModulesGroupByType",
+        replacement_object_id="crt-grenoble-reader-data-source-step"
+    )
+)
+
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.list_element_substitution(
+        obj_class="CRTReaderApplication",
+        obj_id="crt-data-source-01",
+        rel_name="queue_rules",
+        list_index=0,
+        replacement_object_class="QueueConnectionRule",
+        replacement_object_id="crt-grenoble-raw-data-rule"
+    )
+)
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.list_element_substitution(
+        obj_class="ReadoutApplication",
+        obj_id="socket-ru-01",
+        rel_name="queue_rules",
+        list_index=1,
+        replacement_object_class="QueueConnectionRule",
+        replacement_object_id="crt-grenoble-callback-raw-data-rule"
+    )
+)
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.relationship_substitution(
+        obj_class="ReadoutApplication",
+        obj_id="socket-ru-01",
+        rel_name="link_handler",
+        replacement_object_class="DataHandlerConf",
+        replacement_object_id="def-crt-grenoble-link-handler"
+    )
+)
 
 def host_is_at_ehn1(hostname):
     return re.match(r"^(np02|np04)-srv-\d{3}$", hostname) or re.match(r"^(np02|np04)-srv-\d{3}.cern.ch$", hostname)

--- a/plugins/CRTBernReaderModule.cpp
+++ b/plugins/CRTBernReaderModule.cpp
@@ -47,9 +47,6 @@ constexpr uint64_t fake_stream_id = 0;
  */
 constexpr uint64_t fake_block_length = 0x382;
 
-// TODO (DTE): Hardcoded source ID
-constexpr uint64_t source_id = 1002;
-  
 /**
  * @brief Calculate the next fake sequence ID for a packet
  * @param seq_id Fake packet sequence ID
@@ -157,6 +154,7 @@ CRTBernReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mf
       callback_mode = true;
     }
 
+    m_source_id = queue->get_source_id();
     auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
     register_node(queue->UID(), ptr);
   }
@@ -261,7 +259,7 @@ CRTBernReaderModule::handle_eth_payload(char* payload, std::size_t size)
   //auto* daq_header = reinterpret_cast<dunedaq::detdataformats::DAQEthHeader*>(payload);
   //auto src_id = m_stream_id_to_source_id[src_rx_q][(unsigned)daq_header->stream_id];
 
-  if ( auto src_it = m_sources.find(source_id); src_it != m_sources.end()) {
+  if ( auto src_it = m_sources.find(m_source_id); src_it != m_sources.end()) {
     src_it->second->handle_payload(payload, size);
   } else {
     // Really bad -> unexpeced StreamID in UDP Payload.

--- a/plugins/CRTBernReaderModule.hpp
+++ b/plugins/CRTBernReaderModule.hpp
@@ -100,7 +100,8 @@ private:
    * @brief Data sources
    */
   using sid_to_source_map_t = std::map<int, std::shared_ptr<SourceConcept>>;
-  sid_to_source_map_t m_sources;    
+  sid_to_source_map_t m_sources;
+  uint32_t m_source_id; // NOLINT(build/unsigned)
 
   /**
    * @brief Configured packet transmission rate in kHz

--- a/plugins/CRTGrenobleReaderModule.cpp
+++ b/plugins/CRTGrenobleReaderModule.cpp
@@ -47,9 +47,6 @@ constexpr uint64_t fake_stream_id = 0;
  */
 constexpr uint64_t fake_block_length = 0x382;
 
-// TODO (DTE): Hardcoded source ID
-constexpr uint64_t source_id = 1001;
-
 /**
  * @brief Calculate the next fake sequence ID for a packet
  * @param seq_id Fake packet sequence ID
@@ -157,6 +154,7 @@ CRTGrenobleReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager
       callback_mode = true;
     }
 
+    m_source_id = queue->get_source_id();
     auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
     register_node(queue->UID(), ptr);
   }
@@ -261,7 +259,7 @@ CRTGrenobleReaderModule::handle_eth_payload(char* payload, std::size_t size)
   //auto* daq_header = reinterpret_cast<dunedaq::detdataformats::DAQEthHeader*>(payload);
   //auto src_id = m_stream_id_to_source_id[src_rx_q][(unsigned)daq_header->stream_id];
 
-  if ( auto src_it = m_sources.find(source_id); src_it != m_sources.end()) {
+  if ( auto src_it = m_sources.find(m_source_id); src_it != m_sources.end()) {
     src_it->second->handle_payload(payload, size);
   } else {
     // Really bad -> unexpeced StreamID in UDP Payload.

--- a/plugins/CRTGrenobleReaderModule.hpp
+++ b/plugins/CRTGrenobleReaderModule.hpp
@@ -100,7 +100,8 @@ private:
    * @brief Data sources
    */
   using sid_to_source_map_t = std::map<int, std::shared_ptr<SourceConcept>>;
-  sid_to_source_map_t m_sources;    
+  sid_to_source_map_t m_sources;
+  uint32_t m_source_id; // NOLINT(build/unsigned)
 
   /**
    * @brief Configured packet transmission rate in kHz


### PR DESCRIPTION
... from daqsystemtest/example-configs.data.xml and makes local modifications, as needed.

## Description

The changes in this PR take advantage of the changes in our example-configs, as described in DUNE-DAQ/daq-deliverables#181.

## Testing Suggestions

Please see the suggestions in the parent Issue, DUNE-DAQ/daq-deliverables#181.