### PR TITLE
Johnfreeman/merge prep release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(crtmodules VERSION 2.1.0)
+project(crtmodules VERSION 2.1.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ SET_SOURCE_FILES_PROPERTIES( main.c PROPERTIES COMPILE_FLAGS "-Wno-pointer-sign 
 
 # See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/#daq_add_unit_test
 
-daq_add_unit_test(Placeholder_test LINK_LIBRARIES)  # Placeholder_test should be replaced with real unit tests
+# daq_add_unit_test(Placeholder_test LINK_LIBRARIES)  # Placeholder_test should be replaced with real unit tests
 
 ##############################################################################
 


### PR DESCRIPTION
The `johnfreeman/merge_prep-release` branch is an intermediary intended to de-facto merge the `prep-release/fddaq-v5.4.0` branch into `develop`.  A test build was successfully performed earlier today (`MRG2FD_DEV_250903_A9`) and integration tests were successful (https://github.com/DUNE-DAQ/daq-release/actions/runs/17444202007).