### PR TITLE
Modified the crt_reader_test so that it uses a random port for…

### DIFF
--- a/integtest/crt_reader_test.py
+++ b/integtest/crt_reader_test.py
@@ -3,6 +3,7 @@ import os
 import re
 import copy
 
+from daqconf.utils import find_free_port
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 
@@ -34,6 +35,14 @@ common_config_obj.config_db = (
 onebyone_local_crt_bern_conf = copy.deepcopy(common_config_obj)
 onebyone_local_crt_bern_conf.session = "local-socket-1x1-config"
 
+new_port = find_free_port()
+onebyone_local_crt_bern_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="SocketDataSender",
+        obj_id="socket_sender_crt",
+        updates={"port": new_port},
+    )
+)
 onebyone_local_crt_bern_conf.config_substitutions.append(
     data_classes.relationship_substitution(
         obj_class="CRTReaderApplication",
@@ -67,6 +76,14 @@ onebyone_local_crt_bern_conf.config_substitutions.append(
 onebyone_local_crt_grenoble_conf = copy.deepcopy(common_config_obj)
 onebyone_local_crt_grenoble_conf.session = "local-socket-1x1-config"
 
+new_port = find_free_port()
+onebyone_local_crt_grenoble_conf.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="SocketDataSender",
+        obj_id="socket_sender_crt",
+        updates={"port": new_port},
+    )
+)
 onebyone_local_crt_grenoble_conf.config_substitutions.append(
     data_classes.relationship_substitution(
         obj_class="CRTReaderApplication",


### PR DESCRIPTION
… the communication between the reader app and the readout app (so that we don't get port collisions if/when we run multiple integtests at the same time).


## Description

This change is part of a set of changes that avoids the use of a hard-coded port number for the boost::asio socket communication.  This avoids problem when multiple copies of the same integtest are run at the same time.

These changes depend on corresponding ones in the `daqconf` repo, namely DUNE-DAQ/daqconf#595.

## Testing Suggestions

Please see the suggestions in the parent Issue, DUNE-DAQ/daq-deliverables#189.