### PR TITLE
Remove DataMoveCallbackRegistry, use IOManager direct callbacks instead

### DIFF
--- a/plugins/CRTBernReaderModule.cpp
+++ b/plugins/CRTBernReaderModule.cpp
@@ -143,19 +143,8 @@ CRTBernReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mf
       throw err;
     }
 
-    // Check for CB prefix indicating Callback use
-    const char delim = '_';
-    const std::string target = queue->UID();
-    std::vector<std::string> words;
-    tokenize(target, delim, words);
-
-    bool callback_mode = false; // TODO (DTE) : Make callback mode work?
-    if (words.front() == "cb") {
-      callback_mode = true;
-    }
-
     m_source_id = queue->get_source_id();
-    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
+    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID());
     register_node(queue->UID(), ptr);
   }
 }
@@ -190,11 +179,6 @@ CRTBernReaderModule::do_scrap(const CommandData_t& /*obj*/)
 void
 CRTBernReaderModule::do_start(const CommandData_t& /*startobj*/)
 {
-  // Setup callbacks on all sourcemodels
-  for (auto& [sourceid, source] : m_sources) {
-    source->acquire_callback();
-  }
-
   enable_flow();  
 
   m_packet_count = 0;

--- a/plugins/CRTGrenobleReaderModule.cpp
+++ b/plugins/CRTGrenobleReaderModule.cpp
@@ -143,19 +143,8 @@ CRTGrenobleReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager
       throw err;
     }
 
-    // Check for CB prefix indicating Callback use
-    const char delim = '_';
-    const std::string target = queue->UID();
-    std::vector<std::string> words;
-    tokenize(target, delim, words);
-
-    bool callback_mode = false; // TODO (DTE) : Make callback mode work?
-    if (words.front() == "cb") {
-      callback_mode = true;
-    }
-
     m_source_id = queue->get_source_id();
-    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
+    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID());
     register_node(queue->UID(), ptr);
   }
 }
@@ -190,11 +179,6 @@ CRTGrenobleReaderModule::do_scrap(const CommandData_t& /*obj*/)
 void
 CRTGrenobleReaderModule::do_start(const CommandData_t& /*startobj*/)
 {
-  // Setup callbacks on all sourcemodels
-  for (auto& [sourceid, source] : m_sources) {
-    source->acquire_callback();
-  }
-
   m_packet_count = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -26,7 +26,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTG
 namespace crtmodules {
 
 std::shared_ptr<SourceConcept>
-createSourceModel(const std::string& conn_uid, bool callback_mode)
+createSourceModel(const std::string& conn_uid)
 {
   auto datatypes = dunedaq::iomanager::IOManager::get()->get_datatypes(conn_uid);
   if (datatypes.size() != 1) {
@@ -40,12 +40,12 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
   if (raw_dt.find("CRTBernFrame") != std::string::npos) {
     auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::CRTBernTypeAdapter>>();
     source_model->set_sink_name(conn_uid);
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     return source_model;
   } else if (raw_dt.find("CRTGrenobleFrame") != std::string::npos) {
     auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::CRTGrenobleTypeAdapter>>();
     source_model->set_sink_name(conn_uid);
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     return source_model;
   }
 

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -38,8 +38,7 @@ namespace dunedaq {
       SourceConcept& operator=(SourceConcept&&) = delete;      ///< SourceConcept is not move-assignable
 
       //  virtual void init(const nlohmann::json& args) = 0;
-      virtual void set_sink(const std::string& sink_name, bool callback_mode) = 0;
-      virtual void acquire_callback() = 0;
+      virtual void set_sink(const std::string& sink_name) = 0;
       //  virtual void conf(const nlohmann::json& args) = 0;
       //  virtual void start(const nlohmann::json& args) = 0;
       //  virtual void stop(const nlohmann::json& args) = 0;

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -10,7 +10,6 @@
 
 #include "SourceConcept.hpp"
 
-
 #include "iomanager/IOManager.hpp"
 #include "iomanager/Sender.hpp"
 #include "logging/Logging.hpp"
@@ -18,8 +17,7 @@
 #include "crtmodules/opmon/SourceModel.pb.h"
 
 // #include "datahandlinglibs/utils/ReusableThread.hpp"
-#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
-#include "datahandlinglibs/utils/BufferCopy.hpp" 
+#include "datahandlinglibs/utils/BufferCopy.hpp"
 
 // #include <folly/ProducerConsumerQueue.h>
 // #include <nlohmann/json.hpp>
@@ -28,7 +26,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-
 
 namespace dunedaq::crtmodules {
 
@@ -51,37 +48,17 @@ public:
    */
   SourceModel()
     : SourceConcept()
-  {}
+  {
+  }
   ~SourceModel() {}
 
-  void set_sink(const std::string& sink_name, bool callback_mode) override
+  void set_sink(const std::string& sink_name) override
   {
-    m_callback_mode = callback_mode;
-    if (callback_mode) {
-      TLOG_DEBUG(5) << "Callback mode requested. Won't acquire iom sender!";
+    if (m_sink_is_set) {
+      TLOG_DEBUG(5) << "SourceModel sink is already set in initialized!";
     } else {
-      if (m_sink_is_set) {
-        TLOG_DEBUG(5) << "SourceModel sink is already set in initialized!";
-      } else {
-        m_sink_queue = get_iom_sender<TargetPayloadType>(sink_name);
-        m_sink_is_set = true;
-      }
-    }
-  }
-
-  void acquire_callback() override
-  {
-    if (m_callback_mode) {
-      if (m_callback_is_acquired) {
-        TLOG_DEBUG(5) << "SourceModel callback is already acquired!";
-      } else {
-        // Getting DataMoveCBRegistry
-        auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
-        m_sink_callback = dmcbr->get_callback<TargetPayloadType>(inherited::m_sink_name);
-        m_callback_is_acquired = true;
-      }
-    } else {
-      TLOG_DEBUG(5) << "Won't acquire callback, as IOM sink is set!";
+      m_sink_queue = get_iom_sender<TargetPayloadType>(sink_name);
+      m_sink_is_set = true;
     }
   }
 
@@ -93,54 +70,46 @@ public:
     if (push_out) {
 
       TargetPayloadType& target_payload = *reinterpret_cast<TargetPayloadType*>(message);
-  
-      if (m_callback_mode) {
-        (*m_sink_callback)(std::move(target_payload));
-      } else {
-        if (!m_sink_queue->try_send(std::move(target_payload), iomanager::Sender::s_no_block)) {
-          //if(m_dropped_packets == 0 || m_dropped_packets%10000) {
-          //  TLOG() << "Dropped data " << m_dropped_packets;
-          //}
-          ++m_dropped_packets;
-        }
+
+      if (!m_sink_queue->try_send(std::move(target_payload), iomanager::Sender::s_no_block)) {
+        // if(m_dropped_packets == 0 || m_dropped_packets%10000) {
+        //   TLOG() << "Dropped data " << m_dropped_packets;
+        // }
+        ++m_dropped_packets;
       }
 
     } else {
       TargetPayloadType target_payload;
       uint32_t bytes_copied = 0;
-      datahandlinglibs::buffer_copy(message, size, static_cast<void*>(&target_payload), bytes_copied, sizeof(target_payload));
+      datahandlinglibs::buffer_copy(
+        message, size, static_cast<void*>(&target_payload), bytes_copied, sizeof(target_payload));
     }
 
     return true;
   }
 
-  std::size_t get_frame_size() const override {
-    TargetPayloadType target_payload; 
+  std::size_t get_frame_size() const override
+  {
+    TargetPayloadType target_payload;
     return target_payload.get_frame_size(); // TODO (DTE): Could be a static function?
   }
-    
-  void generate_opmon_data() override {
+
+  void generate_opmon_data() override
+  {
 
     opmon::SourceInfo info;
-    info.set_dropped_frames( m_dropped_packets.load() ); 
+    info.set_dropped_frames(m_dropped_packets.load());
 
-    publish( std::move(info) );
+    publish(std::move(info));
   }
-  
+
 private:
   // Sink internals
   std::string m_sink_id;
   bool m_sink_is_set{ false };
   std::shared_ptr<sink_t> m_sink_queue;
 
-  // Callback internals
-  bool m_callback_mode;
-  bool m_callback_is_acquired{ false };
-  using sink_cb_t = std::shared_ptr<std::function<void(TargetPayloadType&&)>>;
-  sink_cb_t m_sink_callback;
-
-  std::atomic<uint64_t> m_dropped_packets{0};
-
+  std::atomic<uint64_t> m_dropped_packets{ 0 };
 };
 
 } // namespace dunedaq::crtmodules


### PR DESCRIPTION
# Description

See DUNE-DAQ/datahandlinglibs#119 for details. Requires DUNE-DAQ/iomanager#125


## Type of change

- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

