### PR TITLE
Johnfreeman/daq deliverables issue215 fddetdataformats improvements

### DIFF
--- a/plugins/CRTBernReaderModule.cpp
+++ b/plugins/CRTBernReaderModule.cpp
@@ -91,15 +91,13 @@ fake_adc(fddetdataformats::CRTBernFrame& frame)
 void
 fake_data(fddetdataformats::CRTBernFrame& frame, uint64_t& seq_id, uint64_t& timestamp)
 {
-  frame.daq_header.det_id = fake_det_id & 0x3f; //6 bits for det id
-  frame.daq_header.crate_id = 1;
-  frame.daq_header.slot_id = 1;
-  frame.daq_header.stream_id = fake_stream_id;
+  frame.set_geoid(1, 1, fake_stream_id); // crate, slot, stream
+  frame.get_daqheader().det_id = fake_det_id & 0x3f; //6 bits for det id
   fake_sequence_id(seq_id);
-  frame.daq_header.seq_id = seq_id;
-  frame.daq_header.block_length = fake_block_length;
+  frame.get_daqheader().seq_id = seq_id;
+  frame.get_daqheader().block_length = fake_block_length;
   fake_timestamp(timestamp);
-  frame.daq_header.timestamp = timestamp;
+  frame.set_timestamp(timestamp);
   fake_adc(frame);
 }
 

--- a/plugins/CRTGrenobleReaderModule.cpp
+++ b/plugins/CRTGrenobleReaderModule.cpp
@@ -91,15 +91,13 @@ fake_adc(fddetdataformats::CRTGrenobleFrame& frame)
 void
 fake_data(fddetdataformats::CRTGrenobleFrame& frame, uint64_t& seq_id, uint64_t& timestamp)
 {
-  frame.daq_header.det_id = fake_det_id & 0x3f; //6 bits for det id
-  frame.daq_header.crate_id = 1;
-  frame.daq_header.slot_id = 1;
-  frame.daq_header.stream_id = fake_stream_id;
+  frame.set_geoid(1, 1, fake_stream_id); // crate, slot, stream
+  frame.get_daqheader().det_id = fake_det_id & 0x3f; //6 bits for det id
   fake_sequence_id(seq_id);
-  frame.daq_header.seq_id = seq_id;
-  frame.daq_header.block_length = fake_block_length;
+  frame.get_daqheader().seq_id = seq_id;
+  frame.get_daqheader().block_length = fake_block_length;
   fake_timestamp(timestamp);
-  frame.daq_header.timestamp = timestamp;
+  frame.set_timestamp(timestamp);
   fake_adc(frame);
 }
 


### PR DESCRIPTION
# Description

This is only to be merged after the merging of `fddetdataformats`' https://github.com/DUNE-DAQ/fddetdataformats/pull/58 PR. It updates function calls to reflect the fact that member data in frames is made `private` in that PR, although in the specific case of the CRT frames they have a non-`const` version of `get_header` which get used in this PR.  

Testing would essentially be, does the code build? It should be done in concert with the testing of the other repos which have branches with the `johnfreeman/daq-deliverables_issue215_fddetdataformats_improvements` name (`fddetdataformats`, obviously, but also `tpglibs` and `fdreadoutlibs`). 



## Type of change
This is a bug fix in the sense of, `crtmodules` will be broken once the `fddetdataformats` PR is merged unless this feature branch is merged in as well. 

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X] Unit tests pass (e.g. `dbt-build --unittest`)
- [X] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [X] Python tests pass if applicable (e.g. `python -m pytest`)
- [X] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

