### PR TITLE
Updated the integtest to take into account recent changes in the integration test infrastructure

### DIFF
--- a/integtest/crt_frame_builder_test.py
+++ b/integtest/crt_frame_builder_test.py
@@ -6,12 +6,15 @@ import copy
 from daqconf.utils import find_free_port
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.basic_checks as basic_checks
+from integrationtest.verbosity_helper import IntegtestVerbosityLevels
+
+import functools
+print = functools.partial(print, flush=True)  # always flush print() output
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
 # Values that help determine the running conditions
-number_of_data_producers = 4
-number_of_builder_apps = 2
 run_duration = 20  # seconds
 
 # Default values for validation parameters
@@ -24,21 +27,19 @@ ignored_logfile_problems = {
     ],    
 }
 
-common_config_obj = data_classes.drunc_config()
-common_config_obj.dro_map_config.n_streams = number_of_data_producers
-common_config_obj.dro_map_config.n_apps = number_of_builder_apps
+common_config_obj = data_classes.integtest_params_for_predefined_dunedaq_config()
 # 22-Jan-2026, KAB: added the use of the DAQSYSTEMTEST_SHARE env var as part of
 # specifying the location of the example-configs.data.xml file.  This is more
 # reliable than using a relative path to a parallel directory with the daqsystemtest
 # code in it.  Of course, this new model has the feature that users will need to
 # rebuild their software area if they make changes to the configuration entities
 # in a local copy of the daqsystemtest repo before this code will see those changes.
-common_config_obj.config_db = (
+common_config_obj.predefined_config_db = (
     os.environ.get("DAQSYSTEMTEST_SHARE") + "/config/daqsystemtest/example-configs.data.xml"
 )
 
 onebyone_local_crt_bern_conf = copy.deepcopy(common_config_obj)
-onebyone_local_crt_bern_conf.session = "local-socket-1x1-config"
+onebyone_local_crt_bern_conf.config_session_name = "local-socket-1x1-config"
 
 new_local_port = find_free_port()
 new_remote_port = find_free_port()
@@ -60,7 +61,7 @@ onebyone_local_crt_bern_conf.config_substitutions.append(
 )
 
 onebyone_local_crt_grenoble_conf = copy.deepcopy(common_config_obj)
-onebyone_local_crt_grenoble_conf.session = "local-socket-1x1-config"
+onebyone_local_crt_grenoble_conf.config_session_name = "local-socket-1x1-config"
 
 new_local_port = find_free_port()
 new_remote_port = find_free_port()
@@ -180,31 +181,22 @@ confgen_arguments = {
     "Local CRT Grenoble 1x1 Conf": onebyone_local_crt_grenoble_conf,
 }
 
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start --run-number 101 wait 5 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
-def test_nanorc_success(run_nanorc):
-    # print the name of the current test
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    banner_line = re.sub(".", "=", current_test)
-    print(banner_line)
-    print(current_test)
-    print(banner_line)    
+def test_dunerc_success(run_dunerc, caplog):
+    # checks for run control success, problems during pytest setup, etc.
+    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0 
-
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems,
+            verbosity_helper=run_dunerc.verbosity_helper
         )


### PR DESCRIPTION
# Description

Now that the code changes from the `prep-release/fddaq-v5.6.0` branches have been merged to `develop` branches, I've updated the integration test in this repo (`crt_frame_builder_test.py`) to take into account the recent changes that have been made in the integration test infrastructure.

The `crt_frame_builder_test` should now run successfully.  

It can be tested with `dunedaq_integtest_bundle.sh -r crtmodules`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

